### PR TITLE
Require verbose param registration

### DIFF
--- a/flow_runner.go
+++ b/flow_runner.go
@@ -151,14 +151,18 @@ func (f *flowRunner) runTask(ctx context.Context, task Task) bool {
 	for _, param := range task.Parameters {
 		paramValues[param.Name()] = f.paramValues[param.Name()]
 	}
+
+	verbose := true // by default print everything (verbose)
 	if f.verbose != nil {
-		paramValues[f.verbose.Name()] = f.paramValues[f.verbose.Name()]
+		// if verbose flag is registered then check its value
+		value, existing := f.paramValues[f.verbose.Name()]
+		verbose = existing && value.Get().(bool)
 	}
 
 	failed := false
 	measuredCommand := func(tf *TF) {
 		w := tf.Output()
-		if (f.verbose != nil) && !f.verbose.Get(tf) {
+		if !verbose {
 			w = &strings.Builder{}
 		}
 


### PR DESCRIPTION
## Why

If a `Task` wants to use any parameter I want to make sure that it is assigned to `Task.Parameters`.

## What

Do not assign verbose param to each command. The implementation is dirty, but I think it might be good enough before we have more "global" parameters for `Taskflow` (not only for a `Task`).